### PR TITLE
include private/median_common.h in pdqselect.h

### DIFF
--- a/include/miniselect/pdqselect.h
+++ b/include/miniselect/pdqselect.h
@@ -45,6 +45,8 @@
 #define PDQSORT_PREFER_MOVE(x) (x)
 #endif
 
+#include "private/median_common.h"
+
 namespace miniselect {
 namespace pdqsort_detail {
 


### PR DESCRIPTION
If you just include pdqselect.h, a compile will fail because of a reference to `median_common_detail::CompareRefType`. This change fixes that issue by including private/median_common.h.